### PR TITLE
Change color modification to HCT-based

### DIFF
--- a/app/src/main/java/com/drdisagree/colorblendr/utils/ColorModifiers.kt
+++ b/app/src/main/java/com/drdisagree/colorblendr/utils/ColorModifiers.kt
@@ -65,7 +65,7 @@ object ColorModifiers {
                 }
             }
         } else {
-            if (backgroundSaturation && style != MONET.MONOCHROMATIC) {
+            if (backgroundSaturation && style != MONET.MONOCHROMATIC && style != MONET.RAINBOW) {
                 // Set background saturation
                 palette.replaceAll { o: Int ->
                     ColorUtil.modifySaturation(

--- a/app/src/main/java/com/drdisagree/colorblendr/utils/ColorUtil.kt
+++ b/app/src/main/java/com/drdisagree/colorblendr/utils/ColorUtil.kt
@@ -16,6 +16,7 @@ import com.drdisagree.colorblendr.config.RPrefs.getInt
 import com.drdisagree.colorblendr.utils.ColorSchemeUtil.MONET
 import com.drdisagree.colorblendr.utils.ColorSchemeUtil.generateColorPalette
 import com.drdisagree.colorblendr.utils.cam.Cam
+import com.drdisagree.colorblendr.utils.cam.CamUtils
 import com.google.gson.reflect.TypeToken
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.min
@@ -143,16 +144,17 @@ object ColorUtil {
     fun modifySaturation(color: Int, saturation: Int): Int {
         val saturationFloat = (saturation - 100) / 100f
 
-        val hsl = FloatArray(3)
-        ColorUtils.colorToHSL(color, hsl)
+        val cam = Cam.fromInt(color)
+        var chroma = cam.chroma
+        val lstar = CamUtils.lstarFromInt(color)
 
         if (saturationFloat > 0) {
-            hsl[1] += ((1 - hsl[1]) * saturationFloat)
+            chroma = 100f * (chroma / (chroma * saturationFloat + 100f) + saturationFloat)
         } else if (saturationFloat < 0) {
-            hsl[1] += (hsl[1] * saturationFloat)
+            chroma += (chroma * saturationFloat)
         }
 
-        return ColorUtils.HSLToColor(hsl)
+        return Cam.getInt(cam.hue, chroma, lstar)
     }
 
     fun modifyLightness(color: Int, lightness: Int, idx: Int): Int {
@@ -173,12 +175,10 @@ object ColorUtil {
             }
         }
 
-        val hsl = FloatArray(3)
-        ColorUtils.colorToHSL(color, hsl)
+        val cam = Cam.fromInt(color)
+        val lstar = 100f * (shade + lightnessFloat)
 
-        hsl[2] = shade + lightnessFloat
-
-        return ColorUtils.HSLToColor(hsl)
+        return Cam.getInt(cam.hue, cam.chroma, lstar)
     }
 
     fun modifyBrightness(color: Int, brightnessPercentage: Int): Int {


### PR DESCRIPTION
This pull request changes how color modification works.

Currently, ColorBlendr modifies color palette based on HSL which can make inconsistency in lightness.
I changed color modification code to HCT-based which improves lightness consistency when modifying colors.

This breaks existing color modification settings, please review the code before merging.