### PR TITLE
Get more colors from the wallpaper

### DIFF
--- a/app/src/main/java/com/drdisagree/colorblendr/utils/wallpaper/WallpaperColorUtil.kt
+++ b/app/src/main/java/com/drdisagree/colorblendr/utils/wallpaper/WallpaperColorUtil.kt
@@ -148,9 +148,7 @@ object WallpaperColorUtil {
         bitmapTemp.getPixels(pixels, 0, width, 0, 0, width, height)
 
         val wallpaperColors = ArrayList(
-            Score.score(
-                QuantizerCelebi.quantize(pixels, 25)
-            )
+            Score.score(QuantizerCelebi.quantize(pixels, 128), 12)
         )
 
         return if (wallpaperColors.isEmpty()) ColorUtil.monetAccentColors else wallpaperColors


### PR DESCRIPTION
When ColorBlendr picks colors from the wallpaper, `Score.score` returns up to 4 colors by default.
This number can be increased by adding an argument to the `Score.score` call so we can get more colors.

@Mahmud0808, how many colors do you want? In this draft currently has up to 12 colors.